### PR TITLE
+ Resolve #32

### DIFF
--- a/tase/common/patterns.py
+++ b/tase/common/patterns.py
@@ -1871,16 +1871,14 @@ application/x-tgsticker		tgs
 mimetypes = mimetypes.MimeTypes()
 mimetypes.readfp(StringIO(mime_types))
 
-telegram_username_pattern = re.compile(
-    r"(?:@|(?:(?:(?:https?://)?t(?:elegram)?)\.me\/))(?P<username>[a-zA-Z0-9_]{5,32})",
+telegram_link_pattern = re.compile(
+    r"(?:(?:https?://)?(?:www\.)?(?:t(?:elegram)?\.(?:org|me|dog)/(?:joinchat/|\+))([\w-]+)|(?:https?://)?(?:www\.)?(?:t(?:elegram)?\.(?:org|me|dog)/)(proxy\?.+)|(?:https?://)?(?:www\.)?(?:t(?:elegram)?\.(?:org|me|dog)/)(c/\d+/\d+/?)|(?:(?:@|(?:(?:(?:https?://)?t(?:elegram)?)\.me\/))(?P<username1>[a-zA-Z0-9_]{5,32})|((?:https?://)?(?P<username0>[a-zA-Z0-9_]{5,32})(\.t(elegram)?\.me)))(?:(/\d+/?)|.+)?)",
     re.IGNORECASE,
-)
-url_with_protocol_pattern = re.compile(
-    "[a-zA-Z]+:\\/\\/(?:www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*)"
 )
 
 url_pattern = re.compile(
-    "[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*)"
+    r"(?:[a-zA-Z]+://)?(?:www\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*)",
+    re.IGNORECASE,
 )
 
 punctuation_pattern = re.compile(r"[" + string.punctuation + "]")
@@ -1929,12 +1927,12 @@ def guess_file_name(file_name: str) -> Optional[str]:
     return temp
 
 
-def remove_usernames(
+def remove_telegram_links(
     text: str,
     extra_strings_to_remove: Deque[str] = None,
 ) -> Optional[str]:
     """
-    Remove usernames and `extra_string_to_remove` parameter from the given `text`
+    Remove usernames, telegram internal links, and `extra_string_to_remove` parameter from the given `text`
 
     Parameters
     ----------
@@ -1952,7 +1950,7 @@ def remove_usernames(
     if text is None:
         return None
 
-    text = telegram_username_pattern.sub("", text)
+    text = telegram_link_pattern.sub("", text)
     if extra_strings_to_remove is not None and len(extra_strings_to_remove):
         for to_remove in extra_strings_to_remove:
             if to_remove is None:
@@ -1985,7 +1983,6 @@ def remove_urls(
     if text is None:
         return None
 
-    text = url_with_protocol_pattern.sub("", text)
     text = url_pattern.sub("", text)
 
     if not len(text):

--- a/tase/db/arangodb/graph/vertices/audio.py
+++ b/tase/db/arangodb/graph/vertices/audio.py
@@ -7,7 +7,7 @@ import pyrogram
 from arango import CursorEmptyError
 
 from tase.common.patterns import (
-    remove_usernames,
+    remove_telegram_links,
     remove_urls,
     guess_file_name,
     remove_punctuations,
@@ -181,17 +181,17 @@ class Audio(BaseVertex):
         else:
             has_checked_forwarded_message = None
 
-        title = remove_usernames(title, extra_string_to_remove)
-        caption = remove_usernames(
+        title = remove_telegram_links(title, extra_string_to_remove)
+        caption = remove_telegram_links(
             telegram_message.caption
             if telegram_message.caption
             else telegram_message.text,
             extra_string_to_remove,
         )
-        performer = remove_usernames(
+        performer = remove_telegram_links(
             getattr(audio, "performer", None), extra_string_to_remove
         )
-        file_name = remove_usernames(audio.file_name, extra_string_to_remove)
+        file_name = remove_telegram_links(audio.file_name, extra_string_to_remove)
 
         title = remove_punctuations(remove_urls(title))
         caption = remove_punctuations(remove_urls(caption))

--- a/tase/db/elasticsearchdb/models/audio.py
+++ b/tase/db/elasticsearchdb/models/audio.py
@@ -8,7 +8,7 @@ from elastic_transport import ObjectApiResponse
 from pydantic import Field
 
 from tase.common.patterns import (
-    remove_usernames,
+    remove_telegram_links,
     remove_urls,
     guess_file_name,
     remove_punctuations,
@@ -178,17 +178,17 @@ class Audio(BaseDocument):
         if telegram_message.forward_from_chat:
             extra_string_to_remove.append(telegram_message.forward_from_chat.username)
 
-        title = remove_usernames(title, extra_string_to_remove)
-        caption = remove_usernames(
+        title = remove_telegram_links(title, extra_string_to_remove)
+        caption = remove_telegram_links(
             telegram_message.caption
             if telegram_message.caption
             else telegram_message.text,
             extra_string_to_remove,
         )
-        performer = remove_usernames(
+        performer = remove_telegram_links(
             getattr(audio, "performer", None), extra_string_to_remove
         )
-        file_name = remove_usernames(audio.file_name, extra_string_to_remove)
+        file_name = remove_telegram_links(audio.file_name, extra_string_to_remove)
 
         title = remove_punctuations(remove_urls(title))
         caption = remove_punctuations(remove_urls(caption))

--- a/tase/telegram/client/tasks/extract_usernames_task.py
+++ b/tase/telegram/client/tasks/extract_usernames_task.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Union
 import pyrogram
 from pydantic import Field
 
-from tase.common.patterns import telegram_username_pattern
+from tase.common.patterns import telegram_link_pattern
 from tase.common.utils import datetime_to_timestamp, prettify
 from tase.db import DatabaseClient
 from tase.db.arangodb.enums import MentionSource
@@ -34,9 +34,19 @@ class ExtractUsernamesTask(BaseTask):
             return None
 
         def find(text_: str, mention_source_: MentionSource):
-            for match in telegram_username_pattern.finditer(text_):
+            for match in telegram_link_pattern.finditer(text_):
+                username0 = match.group("username0")
+                username1 = match.group("username1")
+
+                if username0 is not None:
+                    username = username0
+                elif username1 is not None:
+                    username = username1
+                else:
+                    continue
+
                 self.add_username(
-                    match.group("username"),
+                    username,
                     is_direct_mention,
                     message,
                     mention_source_,


### PR DESCRIPTION
This update closes issue #32. On top of adding support for the new telegram username pattern, I updated the telegram link pattern to account for all telegram internal links, like `chat join links`, `bot command deep links`, `proxy links`, `message links`, and...

Moreover, I integrated both URL patterns into one pattern for ease of use.